### PR TITLE
Fix build error

### DIFF
--- a/configs.py
+++ b/configs.py
@@ -185,8 +185,9 @@ class AndroidConfig(_BaseConfig):
     @property
     def _toolchain_builtins(self) -> Path:
         """The path with libgcc.a to include in linker search path."""
+        version_number = '8.4.0' if self.target_arch == hosts.Arch.RISCV64 else '4.9.x'
         return (paths.GCC_ROOT / self._toolchain_path / '..' / 'lib' / 'gcc' /
-                self._toolchain_path.name / '4.9.x')
+                self._toolchain_path.name / version_number)
 
     @property
     def ldflags(self) -> List[str]:

--- a/do_build.py
+++ b/do_build.py
@@ -256,9 +256,10 @@ def cross_compile_configs(toolchain, platform=False, static=False):
         defines['LLVM_CONFIG_PATH'] = llvm_config
 
         # Include the directory with libgcc.a to the linker search path.
+        version_number = '8.4.0' if arch == hosts.Arch.RISCV64 else '4.9.x'
         toolchain_builtins = os.path.join(
             toolchain_root, toolchain_path, '..', 'lib', 'gcc',
-            os.path.basename(toolchain_path), '4.9.x')
+            os.path.basename(toolchain_path), version_number)
         # The 32-bit libgcc.a is sometimes in a separate subdir
         if arch == hosts.Arch.I386:
             toolchain_builtins = os.path.join(toolchain_builtins, '32')


### PR DESCRIPTION
The directory that include libgcc.a is named '8.4.0' in repo platform-prebuilts-gcc-linux-x86-riscv64-riscv64-linux-android-8.1. Here changed the directory name